### PR TITLE
fix: vite dist folder

### DIFF
--- a/.github/workflows/deploy_react_workflow.yml
+++ b/.github/workflows/deploy_react_workflow.yml
@@ -30,4 +30,4 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
-          folder: build
+          folder: dist


### PR DESCRIPTION
- Vite uses `dist`, not `build`